### PR TITLE
Re-deploy frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,14 @@ services:
     build:
       context: ./frontend
       target: dev
-    ports: ["3000:3000"]
+    environment:
+      - MATCHING_SERVICE_DOMAIN="http://matching-service:8080"
+    ports:
+      - 3000:3000
   matching-service:
     container_name: matching-service
     build:
       context: ./matching-service
       target: dev
+    ports:
+      - 8080:8080

--- a/frontend/src/configs.js
+++ b/frontend/src/configs.js
@@ -1,5 +1,13 @@
-const URI_USER_SVC = process.env.URI_USER_SVC || 'http://localhost:8000'
+const USER_SERVICE_DOMAIN =
+  process.env.USER_SERVICE_DOMAIN || "http://localhost:8000";
+const USER_SERVICE_PREFIX = "/api/user";
 
-const PREFIX_USER_SVC = '/api/user'
+const MATCHING_SERVICE_DOMAIN =
+  process.env.MATCHING_SERVICE_DOMAIN || "http://localhost:8080";
 
-export const URL_USER_SVC = URI_USER_SVC + PREFIX_USER_SVC
+export const USER_SERVICE_URL = USER_SERVICE_DOMAIN + USER_SERVICE_PREFIX;
+
+/* TODO: figure out a way to toggle between env variables in local and production */
+// export const MATCHING_SERVICE_URL = MATCHING_SERVICE_DOMAIN;
+export const MATCHING_SERVICE_URL =
+  "https://matching-service-pzsuad4zva-as.a.run.app:443/";

--- a/frontend/src/pages/matching-service/SocketContext.js
+++ b/frontend/src/pages/matching-service/SocketContext.js
@@ -1,7 +1,7 @@
 import { createContext } from "react";
 import io from "socket.io-client";
 
-const MATCHING_SERVICE_URL = "http://localhost:8080";
+import { MATCHING_SERVICE_URL } from "../../configs";
 
 let socket = io(MATCHING_SERVICE_URL);
 

--- a/matching-service/Dockerfile
+++ b/matching-service/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /usr/app
 COPY package.json .
 RUN npm install --quiet
 COPY . .
+EXPOSE 8080
 
 FROM base as dev
 CMD ["npm", "run", "dev"]


### PR DESCRIPTION
This pull-request modifies the following:
* changes the url for `matching-service` to that of the production server's
   * was previously set to "localhost:8080"
   * TODO: figure out a way to toggle between env variables in local and production