### PR TITLE
Deploy API gateway

### DIFF
--- a/.github/workflows/manual-deploy.yml
+++ b/.github/workflows/manual-deploy.yml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - frontend
+          - api-gateway
           - matching-service
           - user-service
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,6 +4,12 @@ module "frontend" {
   image_tag = var.frontend_image_tag
 }
 
+module "api-gateway" {
+  source = "./modules/api-gateway"
+
+  image_tag = var.api-gateway_image_tag
+}
+
 module "matching-service" {
   source = "./modules/matching-service"
 

--- a/terraform/modules/api-gateway/main.tf
+++ b/terraform/modules/api-gateway/main.tf
@@ -1,0 +1,43 @@
+variable "image_tag" {
+  type=string
+  default="latest"
+}
+
+resource "google_cloud_run_service" "api-gateway" {
+  name     = "api-gateway"
+  location = "asia-southeast1"
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cs3219-project-ay2223s1-g22/api-gateway:${var.image_tag}"
+      }
+    }
+  }
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}
+
+# Create public access
+data "google_iam_policy" "noauth" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "allUsers",
+    ]
+  }
+}
+
+# Enable public access on Cloud Run service
+resource "google_cloud_run_service_iam_policy" "noauth-api-gateway" {
+  location    = google_cloud_run_service.api-gateway.location
+  project     = google_cloud_run_service.api-gateway.project
+  service     = google_cloud_run_service.api-gateway.name
+  policy_data = data.google_iam_policy.noauth.policy_data
+}
+
+# Return service URL
+output "api-gateway-url" {
+  value = google_cloud_run_service.api-gateway.status[0].url
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -8,6 +8,11 @@ variable "frontend_image_tag" {
 	default="latest"
 }
 
+variable "api-gateway_image_tag" {
+	type=string
+	default="latest"
+}
+
 variable "user-service_image_tag" {
 	type=string
 	default="latest"


### PR DESCRIPTION
This pull-request adds the following:
* terraform configuration files to deploy an instance of the API gateway on GCP
* an option to manually deploy the API gateway in the manual deployment GitHub actions script