### PR TITLE
Implement peer connection status in match room page

### DIFF
--- a/frontend/src/pages/matching-service/LeaveRoomOverlay.js
+++ b/frontend/src/pages/matching-service/LeaveRoomOverlay.js
@@ -31,15 +31,13 @@ const LeaveRoomOverlay = (props) => {
     if (socket) {
       if (socket.connected) {
         console.info(
-          `socket ${socket.id} is still connected, sending leave match to roomNumber: ${state.roomNumber}.`
+            `socket ${socket.id} is still connected, sending leave match to roomNumber: ${state.roomNumber}.`
         );
         onClose();
         socket.disconnect();
-      } else {
-        socket.connect();
       }
+      socket.connect();
       navigate("/matchselection");
-	  socket.connect();
     }
   };
 
@@ -57,12 +55,7 @@ const LeaveRoomOverlay = (props) => {
           </AlertDialogHeader>
 
           <AlertDialogBody>
-            {socketRef.current &&
-              socketRef.current.connected &&
-              "Are you sure you want to leave your peer hanging?"}
-            {socketRef.current &&
-              !socketRef.current.connected &&
-              "Are you sure you want to leave the match?"}
+            {"Are you sure you want to leave the match?"}
           </AlertDialogBody>
 
           <AlertDialogFooter>

--- a/frontend/src/pages/matching-service/MatchRoomPage.js
+++ b/frontend/src/pages/matching-service/MatchRoomPage.js
@@ -15,27 +15,18 @@ const MatchRoomPage = () => {
 	const { getSocket } = useContext(SocketContext);
 	const socketRef = useRef(getSocket(idToken));
 
-  const opponentLeftToast = useToast();
-  const showOpponentLeftToast = () => {
-    opponentLeftToast({
-      title: "Oops! You opponent left the match!",
-      description: "You can continue working on the problem though :)",
-      status: "error",
-      duration: 3000,
-      isClosable: true,
-    });
-  };
+	const reconnectSocket = (sock) => {
+		console.log("sending exit");
+		sock.emit("exit-room", state.roomNumber);
+		sock.disconnect();
+		sock.connect();
+	}
 
 	useEffect(() => {
 		const socket = socketRef.current;
-
-		socket.on("match-over", (message) => {
-			console.log(`got match over event from server: socket -> ${socket.id}`);
-			showOpponentLeftToast();
-		});
-
+		socket.emit("enter-room", state.roomNumber);
 		return () => {
-			socket.off("match-over");
+			reconnectSocket(socket);
 		};
 	}, []);
 

--- a/frontend/src/pages/matching-service/MatchSelectionPage.js
+++ b/frontend/src/pages/matching-service/MatchSelectionPage.js
@@ -124,7 +124,6 @@ function MatchSelectionPage() {
   const handleCancelRequest = () => {
     hideFindingMatchModal();
     cancelQueueRequest();
-    // TODO: send cancellation request to backend
   };
 
   const showFindingMatchModal = () => {

--- a/frontend/src/pages/user-service/NavBar.js
+++ b/frontend/src/pages/user-service/NavBar.js
@@ -159,11 +159,11 @@ function NavBar() {
 					))}
 				{location.pathname == "/matchroom" && (buddyCon ? (
 					<Badge variant="solid" colorScheme="green">
-						Buddy Connected
+						Peer Connected
 					</Badge>
 				) : (
 					<Badge variant="solid" colorScheme="red">
-						Buddy Disconnected
+						Peer Disconnected
 					</Badge>
 				))}
 				<Button variant="link" onClick={() => toggleColorMode()}>

--- a/frontend/src/pages/user-service/NavBar.js
+++ b/frontend/src/pages/user-service/NavBar.js
@@ -22,7 +22,7 @@ import {
 	Badge,
 } from "@chakra-ui/react";
 import { MoonIcon, SunIcon } from "@chakra-ui/icons";
-import { useContext, useState, useRef } from "react";
+import {useContext, useState, useRef, useEffect} from "react";
 import UserContext from "../../UserContext";
 import { useNavigate, useLocation } from "react-router-dom";
 import LeaveRoomOverlay from "../matching-service/LeaveRoomOverlay";
@@ -30,6 +30,7 @@ import {
 	deleteUserAccount,
 	logoutUser,
 } from "../../controller/user-controller";
+import {SocketContext} from "../matching-service/SocketContext";
 
 function NavBar() {
 	const location = useLocation();
@@ -37,6 +38,9 @@ function NavBar() {
 	const { idToken, user, clearUserData } = useContext(UserContext);
 	const { isOpen, onOpen, onClose } = useDisclosure();
 	const [isOverlayOpen, setIsOverlayOpen] = useState(false);
+	const { getSocket } = useContext(SocketContext);
+	const socketRef = useRef(getSocket(idToken));
+	const [buddyCon, setBuddyCon] = useState(true);
 
 	const cancelRef = useRef();
 	const navigate = useNavigate();
@@ -126,6 +130,15 @@ function NavBar() {
 		return username;
 	}
 
+	useEffect(() => {
+		if (socketRef.current) {
+			const socket = socketRef.current;
+			socket.on("buddy-check", ((connected, room) => {
+				setBuddyCon(connected);
+			}))
+		}
+	},[])
+
 	return (
 		<HStack w="100%" px="3%" py="1%" justifyContent="space-between">
 			<LeaveRoomOverlay
@@ -134,7 +147,7 @@ function NavBar() {
 			/>
 			<Heading color="#66ddaa">PeerPrep</Heading>
 			<HStack>
-				{idToken &&
+				{location.pathname !== "/matchroom" && idToken &&
 					(user.emailVerified ? (
 						<Badge variant="solid" colorScheme="green">
 							verified
@@ -144,6 +157,15 @@ function NavBar() {
 							Not verified
 						</Badge>
 					))}
+				{location.pathname == "/matchroom" && (buddyCon ? (
+					<Badge variant="solid" colorScheme="green">
+						Buddy Connected
+					</Badge>
+				) : (
+					<Badge variant="solid" colorScheme="red">
+						Buddy Disconnected
+					</Badge>
+				))}
 				<Button variant="link" onClick={() => toggleColorMode()}>
 					{colorMode === "dark" ? (
 						<SunIcon color="orange.200" />

--- a/matching-service/config.js
+++ b/matching-service/config.js
@@ -24,5 +24,5 @@ var currEnvironment =
 var environmentToExport =
   typeof environments[currEnvironment] == "object"
     ? environments[currEnvironment]
-    : environments.dev;
+    : environments.development;
 export default environmentToExport;

--- a/matching-service/server.js
+++ b/matching-service/server.js
@@ -21,9 +21,9 @@ export function rejoinSocket(server, socket, roomNum) {
 }
 
 export function queueSocket(socket, level) {
-  console.info(`socket ${socket.id} added to ${level} queue.`);
+  console.info(`${socket["username"]} added to ${level} queue.`);
   difficulty[level].push(socket);
-  console.log(`${level} queue after add :${difficulty[level]}`);
+  console.log(`${level} queue after add :${difficulty[level].map(sock => sock.username)}`);
 }
 
 export function cancelQueue(socket) {
@@ -57,35 +57,27 @@ export function alreadyInQueueOrRoom(socket) {
     let isInSomeQueue = false;
     for (let i = 0; i < keyList.length; i++) {
         const currKey = keyList[i];
-        console.log(`${currKey} queue before filter : ${difficulty[currKey]?.map(x => x.uuid).toString()}`);
+        console.log(`${currKey} queue before filter : ${difficulty[currKey]?.map(x => x["username"]).toString()}`);
         difficulty[currKey] = difficulty[currKey].filter(sock => sock.connected);
-        console.log(`${currKey} queue after filter : ${difficulty[currKey]?.map(x => x.uuid).toString()}`);
+        console.log(`${currKey} queue after filter : ${difficulty[currKey]?.map(x => x["username"]).toString()}`);
         const currLevelList = difficulty[currKey].map(sock => sock.uuid);
-        console.log(`checking if user ${socket.uuid} is in ${currLevelList}`);
         isInSomeQueue = isInSomeQueue || currLevelList?.includes(socket.uuid);
     }
-    console.log(`checked if already in queue: ${isInSomeQueue}`);
-    updateSocketsInRoom();
+    console.log(`checked if already in queue: ${isInSomeQueue} or room: ${checkIfSocketInRoom(socket)}`);
     return isInSomeQueue || checkIfSocketInRoom(socket);
 }
 
 export function checkIfSocketInRoom(socket) {
-    return inRoom[socket];
+    return inRoom[socket.username];
 }
 
-function addSocketsToInRoom(sockets, room) {
-    console.log(`adding sockets ${sockets.map(socket => socket.uuid)} to inRoom`);
-    updateSocketsInRoom();
-    sockets.map(sock => inRoom[sock] = room);
+export function addSocketsToInRoom(sockets, room) {
+    console.log(`adding users ${sockets.map(socket => socket.username)} to inRoom`);
+    sockets.map(sock => inRoom[sock.username] = room);
 }
 
-function updateSocketsInRoom() {
-    const socketList = Object.keys(inRoom);
-    socketList.map(sock => {
-        if (!sock.connected) {
-            delete inRoom[sock];
-        }
-    })
+export function removeSocketFromInRoom(socket) {
+    delete inRoom[socket.username];
 }
 
 export async function makeRoom(server, socket, level) {

--- a/questions-service/config/config.js
+++ b/questions-service/config/config.js
@@ -27,5 +27,5 @@ var currEnvironment =
 var environmentToExport =
   typeof environments[currEnvironment] == "object"
     ? environments[currEnvironment]
-    : environments.dev;
+    : environments.development;
 export default environmentToExport;


### PR DESCRIPTION
Remove toast alert when peer leaves the match. Peer status is now displayed on screen, replacing the `verified` status.

